### PR TITLE
Bugfix in digital core

### DIFF
--- a/diana/byoc/driver.py
+++ b/diana/byoc/driver.py
@@ -309,7 +309,7 @@ def driver(mod: tvm.ir.IRModule,
     # Create the model library format file and unpack
     d_diana = DianaDriver(mod, params, build_dir=build_dir,
                           byoc_path=byoc_path)
-    d_diana.tvm_compile(fusion=True, target="soma_dory -layout_transform=0, c")
+    d_diana.tvm_compile(fusion=True, target="soma_dory, c")
     d_diana.add_profiler(measurement="global")
     d_diana.gcc_compile(gcc_opt=3)
     # Make for DIANA

--- a/diana/byoc/utils.py
+++ b/diana/byoc/utils.py
@@ -374,7 +374,7 @@ def create_demo_file(model: TVMCModel, directory: str = "build",
     https://discuss.tvm.apache.org/t/how-to-get-the-input-and-output-of-relay-call-node/8743
     '''
     mod = model.mod
-    params = model.params
+    params = model.params.copy()    # work with copy, we might remove entries in this dict
     directory = pathlib.Path(directory)
     def get_c_type(dtype):
         if dtype == "int8":


### PR DESCRIPTION
It seems that with realistic weights and biases, the DIANA digital accelerator gives different results compared to simulation on x86. This can already be proven through executing a single conv2d layer. This issue was not yet discovered since we were testing with very large random biases. Due to their size, small mistakes in the convolution result itself were covered and not reveald earlier. This issue was discovered by testing with realistic trained weights and biases. In the latter case, the biases were much smaller and differences in computed results between x86 and DIANA were uncovered.

This PR starts with adding a new test case `test_conv2d_reproduce_bug` in test.py to reproduce the problem. The test case sets the random generated biases to zero and runs 3 tests with different kernel sizes (1, 3 and 5).

The cause of this problem is not yet discovered and needs investigation.

Two other modifications were made to fix the other test cases when running on diana:
* removed -layout_transform=0 in driver() function. We need the layout transform to have correct behaviour of diana.
* create_demo_file() removes processed entries from the params dict (where the key starts with `g_`). This is unwanted in some cases so now we work with a copy of that dict in create_demo_file().